### PR TITLE
Remove unnecessary Node installation step

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,15 +24,6 @@ The differences are discussed later in this document.
 :java_version: 1.8
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/prereq_editor_jdk_buildtools.adoc[]
 
-Vaadin needs https://nodejs.org/en/[NodeJS 10.x or later] to generate the front-end
-resource bundle. You can install NodeJS locally to your current project by using the
-following Maven command:
-
-====
-[source,bash]
-----
-mvn com.github.eirslett:frontend-maven-plugin:1.7.6:install-node-and-npm -DnodeVersion="v10.16.3"
-----
 ====
 
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/how_to_complete_this_guide.adoc[]


### PR DESCRIPTION
Starting from Vaadin 14.2.0, Vaadin automatically installs Node  to ~/.vaadin if no global or local Node installation is found. See Vaadin 14.2.0 release notes: https://github.com/vaadin/platform/releases/tag/14.2.0.
Hence, this step should be removed from the guide.