### PR TITLE
chore: change to WebEnvironment.MOCK in tests.

### DIFF
--- a/complete/src/test/java/com/example/crudwithvaadin/MainViewTests.java
+++ b/complete/src/test/java/com/example/crudwithvaadin/MainViewTests.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-@SpringBootTest(classes = MainViewTests.Config.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(classes = MainViewTests.Config.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 public class MainViewTests {
 
 	@Autowired CustomerRepository repository;


### PR DESCRIPTION
It fixes migration to next vaadin version 24.4.x
See: https://github.com/vaadin/hilla/issues/2169