### PR TITLE
Update Dependabot and Gradle files for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,41 +1,32 @@
 version: 2
 updates:
+
   - package-ecosystem: "maven"
-    directory: "/initial/"
+    directories:
+      - "/initial"
+      - "/complete"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
     schedule:
       interval: "monthly"
     target-branch: "main"
+    groups:
+      guide-dependencies-maven:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gradle"
-    directory: "/initial/"
-    ignore:
-      - dependency-name: "org.springframework.*"
-        update-types: ["version-update:semver-patch"]
-      - dependency-name: "com.vaadin.*"
-        update-types: ["version-update:semver-patch"]
-    schedule:
-      interval: "monthly"
-    target-branch: "main"
-
-  - package-ecosystem: "maven"
-    directory: "/complete/"
+    directories:
+      - "/initial"
+      - "/complete"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
     schedule:
       interval: "monthly"
     target-branch: "main"
-
-  - package-ecosystem: "gradle"
-    directory: "/complete/"
-    ignore:
-      - dependency-name: "org.springframework.*"
-        update-types: ["version-update:semver-patch"]
-      - dependency-name: "com.vaadin.*"
-        update-types: ["version-update:semver-patch"]
-    schedule:
-      interval: "monthly"
-    target-branch: "main"
+    groups:
+      guide-dependencies-gradle:
+        patterns:
+          - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ dependency-reduced-pom.xml
 README.html
 initial/frontend/
 complete/frontend/
+initial/src/main/frontend/
+complete/src/main/frontend/

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -1,9 +1,10 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.0'
-	id 'io.spring.dependency-management' version '1.1.5'
-	id 'com.vaadin' version '24.4.1'
+	id 'org.springframework.boot' version '3.3.1'
+	id 'com.vaadin' version '24.4.4'
 }
+
+apply plugin: 'io.spring.dependency-management'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
@@ -14,7 +15,7 @@ repositories {
 }
 
 ext {
-	set('vaadinVersion', "24.4.1")
+	vaadinVersion = '24.4.4'
 }
 
 dependencies {

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -17,7 +17,7 @@
 
 	<properties>
 		<java.version>17</java.version>
-		<vaadin.version>24.4.1</vaadin.version>
+		<vaadin.version>24.4.4</vaadin.version>
 	</properties>
 
 	<dependencies>

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -1,9 +1,10 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.0'
-	id 'io.spring.dependency-management' version '1.1.5'
-	id 'com.vaadin' version '24.4.1'
+	id 'org.springframework.boot' version '3.3.1'
+	id 'com.vaadin' version '24.4.4'
 }
+
+apply plugin: 'io.spring.dependency-management'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
@@ -14,7 +15,7 @@ repositories {
 }
 
 ext {
-	set('vaadinVersion', "24.4.1")
+	vaadinVersion = '24.4.4'
 }
 
 dependencies {

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>
@@ -17,7 +17,7 @@
 
 	<properties>
 		<java.version>17</java.version>
-		<vaadin.version>24.4.1</vaadin.version>
+		<vaadin.version>24.4.4</vaadin.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
This PR lays the foundation for dependabot to better manage version updates in the future. Specifically, there were 3 issues addressed in this PR:
- Gradle build files were using set() instead of = which causes dependabot to miss upgrading the dependency
- Gradle build files were specifying the version of io.spring.dpeendency-management which necessitated logic in the dependabot config, which was not working correctly
- Dependabot was not using groups to limit the number of PRs sent for a given version update

After this update Dependabot should be able to ignore all patch versions going forward for Vaadin.

This commit also updates the Spring Boot and Vaadin versions to the latest patch releases.